### PR TITLE
Add in patches from master ForgeFlower

### DIFF
--- a/FernFlower-Patches/0057-Add-new-command-line-argument-sef-SkipExtraFiles.patch
+++ b/FernFlower-Patches/0057-Add-new-command-line-argument-sef-SkipExtraFiles.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: sciwhiz12 <sciwhiz12@sciwhiz12.tk>
+Date: Thu, 4 Feb 2021 01:50:48 +0800
+Subject: [PATCH] Add new command line argument -sef 'SkipExtraFiles'
+
+Used to skip copying non-class files from the input jars to the output.
+
+diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+index 7940dcfbd89ec1427459aeeac1aebaea30db1899..259e5d276e7a98a379bfcf03a18a4b93a92f4396 100644
+--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
++++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+@@ -64,6 +64,8 @@ public interface IFernflowerPreferences {
+ 
+   String USE_JAD_VARNAMING = "jvn";
+ 
++  String SKIP_EXTRA_FILES = "sef";
++
+   Map<String, Object> DEFAULTS = Collections.unmodifiableMap(new HashMap<String, Object>() {{
+     put(REMOVE_BRIDGE, "1");
+     put(REMOVE_SYNTHETIC, "0");
+@@ -99,5 +101,6 @@ public interface IFernflowerPreferences {
+     put(DUMP_ORIGINAL_LINES, "0");
+     put(INCLUDE_ENTIRE_CLASSPATH, "0");
+     put(USE_JAD_VARNAMING, "0");
++    put(SKIP_EXTRA_FILES, "0");
+   }});
+ }
+diff --git a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
+index e3043962de86e4823458766ff2afda4eb3e71e5f..db51534cb8ac1012460c6de7a6f0ad04101244af 100644
+--- a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
++++ b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
+@@ -68,6 +68,8 @@ public class ContextUnit {
+   }
+ 
+   public void addOtherEntry(String fullPath, String entry) {
++    if (DecompilerContext.getOption(IFernflowerPreferences.SKIP_EXTRA_FILES))
++      return;
+     otherEntries.add(new String[]{fullPath, entry});
+   }
+ 

--- a/FernFlower-Patches/0058-Add-cfg-argument-to-specify-a-config-file.patch
+++ b/FernFlower-Patches/0058-Add-cfg-argument-to-specify-a-config-file.patch
@@ -1,0 +1,100 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: sciwhiz12 <sciwhiz12@sciwhiz12.tk>
+Date: Thu, 4 Feb 2021 01:58:45 +0800
+Subject: [PATCH] Add -cfg argument, to specify a config file
+
+Used to specify a text file which contains additional command line arguments, which will be added in place of the -cfg argument.
+
+diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
+index 06f3b1d3b135a30441cb68e2a7a33eddeaa40a1c..ae6aee3c81c8a9aff3bf13af9ac4b3d8c8c1e2b4 100644
+--- a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
++++ b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
+@@ -23,9 +23,13 @@ import org.jetbrains.java.decompiler.main.extern.IResultSaver;
+ import org.jetbrains.java.decompiler.util.InterpreterUtil;
+ 
+ import java.io.*;
++import java.nio.file.Files;
++import java.nio.file.Path;
++import java.nio.file.Paths;
+ import java.util.*;
+ import java.util.jar.JarOutputStream;
+ import java.util.jar.Manifest;
++import java.util.stream.Stream;
+ import java.util.zip.ZipEntry;
+ import java.util.zip.ZipFile;
+ import java.util.zip.ZipOutputStream;
+@@ -34,6 +38,38 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
+ 
+   @SuppressWarnings("UseOfSystemOutOrSystemErr")
+   public static void main(String[] args) {
++    List<String> params = new ArrayList<>();
++    for (int x = 0; x < args.length; x++) {
++      if (args[x].startsWith("-cfg")) {
++        String path = null;
++        if (args[x].startsWith("-cfg=")) {
++          path = args[x].substring(5);
++        }
++        else if (args.length > x+1) {
++          path = args[++x];
++        }
++        else {
++          System.out.println("Must specify a file when using -cfg argument.");
++          return;
++        }
++        Path file = Paths.get(path);
++        if (!Files.exists(file)) {
++          System.out.println("error: missing config '" + path + "'");
++          return;
++        }
++        try (Stream<String> stream = Files.lines(file)) {
++          stream.forEach(params::add);
++        } catch (IOException e) {
++          System.out.println("error: Failed to read config file '" + path + "'");
++          throw new RuntimeException(e);
++        }
++      }
++      else {
++        params.add(args[x]);
++      }
++    }
++    args = params.toArray(new String[params.size()]);
++
+     if (args.length < 2) {
+       System.out.println(
+         "Usage: java -jar fernflower.jar [-<option>=<value>]* [<source>]+ <destination>\n" +
+@@ -86,12 +122,12 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
+     PrintStreamLogger logger = new PrintStreamLogger(System.out);
+     ConsoleDecompiler decompiler = new ConsoleDecompiler(destination, mapOptions, logger);
+ 
+-    for (File source : lstSources) {
+-      decompiler.addSpace(source, true);
+-    }
+     for (File library : lstLibraries) {
+       decompiler.addSpace(library, false);
+     }
++    for (File source : lstSources) {
++      decompiler.addSpace(source, true);
++    }
+ 
+     decompiler.decompileContext();
+   }
+diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
+index 7bfb139ede3087d6a04975eacc48ac31b3fa9c00..93f8cc7ac1c178de4f2cc1fe86db82c1784b416f 100644
+--- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
++++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
+@@ -107,6 +107,7 @@ public class StructContext {
+       catch (IOException ex) {
+         String message = "Corrupted archive file: " + file;
+         DecompilerContext.getLogger().writeMessage(message, ex);
++        throw new RuntimeException(ex);
+       }
+       if (isArchive) {
+         return;
+@@ -134,6 +135,7 @@ public class StructContext {
+         catch (IOException ex) {
+           String message = "Corrupted class file: " + file;
+           DecompilerContext.getLogger().writeMessage(message, ex);
++          throw new RuntimeException(ex);
+         }
+       }
+       else {

--- a/FernFlower-Patches/0059-Add-a-metadata-file-for-renaming-abstract-parameters.patch
+++ b/FernFlower-Patches/0059-Add-a-metadata-file-for-renaming-abstract-parameters.patch
@@ -1,0 +1,125 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: sciwhiz12 <sciwhiz12@sciwhiz12.tk>
+Date: Thu, 4 Feb 2021 02:11:22 +0800
+Subject: [PATCH] Add a metadata file for renaming abstract parameters
+
+The file is named 'fernflower_abstract_parameter_names.txt', with the format of:
+
+ClassName MethodName Descriptor Param1[ Param2...]
+
+diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+index b90f2ec58cc54cdd9b72257824ec6ceaefbc536e..581ef65be27be38883be48fc6758642953c12468 100644
+--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
++++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+@@ -731,7 +731,8 @@ public class ClassWriter {
+             buffer.append(' ');
+             String parameterName = methodWrapper.varproc.getVarName(new VarVersionPair(index, 0));
+             if ((flags & (CodeConstants.ACC_ABSTRACT | CodeConstants.ACC_NATIVE)) != 0) {
+-                parameterName = methodWrapper.methodStruct.getRenamer().renameAbstractParameter(parameterName, index);
++              String newParameterName = methodWrapper.methodStruct.getRenamer().renameAbstractParameter(parameterName, index);
++              parameterName = !newParameterName.equals(parameterName) ? newParameterName : DecompilerContext.getStructContext().renameAbstractParameter(methodWrapper.methodStruct.getClassStruct().qualifiedName, mt.getName(), mt.getDescriptor(), index - (((flags & CodeConstants.ACC_STATIC) == 0) ? 1 : 0), parameterName);
+             }
+             buffer.append(parameterName == null ? "param" + index : parameterName); // null iff decompiled with errors
+ 
+diff --git a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
+index db51534cb8ac1012460c6de7a6f0ad04101244af..1c2603c2a02ca4ac0da5a0c309ffb8fe3c21e9e2 100644
+--- a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
++++ b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
+@@ -21,12 +21,16 @@ import org.jetbrains.java.decompiler.main.extern.IResultSaver;
+ import org.jetbrains.java.decompiler.struct.lazy.LazyLoader;
+ import org.jetbrains.java.decompiler.struct.lazy.LazyLoader.Link;
+ import org.jetbrains.java.decompiler.util.DataInputFullStream;
++import org.jetbrains.java.decompiler.util.InterpreterUtil;
+ 
++import java.io.File;
+ import java.io.IOException;
++import java.nio.charset.StandardCharsets;
+ import java.util.ArrayList;
+ import java.util.List;
+ import java.util.jar.JarFile;
+ import java.util.jar.Manifest;
++import java.util.zip.ZipFile;
+ 
+ public class ContextUnit {
+ 
+@@ -68,6 +72,24 @@ public class ContextUnit {
+   }
+ 
+   public void addOtherEntry(String fullPath, String entry) {
++    if ("fernflower_abstract_parameter_names.txt".equals(entry)) {
++      byte[] data;
++      try {
++        if (type == TYPE_JAR || type == TYPE_ZIP) {
++          try (ZipFile archive = new ZipFile(fullPath)) {
++            data = InterpreterUtil.getBytes(archive, archive.getEntry(entry));
++          }
++        }
++        else {
++          data = InterpreterUtil.getBytes(new File(fullPath));
++        }
++        DecompilerContext.getStructContext().loadAbstractMetadata(new String(data, StandardCharsets.UTF_8));
++      }
++      catch (IOException e) {
++        String message = "Cannot read fernflower_abstract_parameter_names.txt from " + fullPath;
++        DecompilerContext.getLogger().writeMessage(message, e);
++      }
++    }
+     if (DecompilerContext.getOption(IFernflowerPreferences.SKIP_EXTRA_FILES))
+       return;
+     otherEntries.add(new String[]{fullPath, entry});
+diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
+index 93f8cc7ac1c178de4f2cc1fe86db82c1784b416f..a154193f9b9f698873c62af08d1211d0e79b8ae4 100644
+--- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
++++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
+@@ -17,14 +17,18 @@ package org.jetbrains.java.decompiler.struct;
+ 
+ import org.jetbrains.java.decompiler.main.DecompilerContext;
+ import org.jetbrains.java.decompiler.main.extern.IResultSaver;
++import org.jetbrains.java.decompiler.struct.gen.generics.GenericMain;
++import org.jetbrains.java.decompiler.struct.gen.generics.GenericMethodDescriptor;
+ import org.jetbrains.java.decompiler.struct.lazy.LazyLoader;
+ import org.jetbrains.java.decompiler.util.DataInputFullStream;
+ import org.jetbrains.java.decompiler.util.InterpreterUtil;
+ 
+ import java.io.File;
+ import java.io.IOException;
++import java.util.ArrayList;
+ import java.util.Enumeration;
+ import java.util.HashMap;
++import java.util.List;
+ import java.util.Map;
+ import java.util.jar.JarFile;
+ import java.util.zip.ZipEntry;
+@@ -37,6 +41,7 @@ public class StructContext {
+   private final LazyLoader loader;
+   private final Map<String, ContextUnit> units = new HashMap<String, ContextUnit>();
+   private final Map<String, StructClass> classes = new HashMap<String, StructClass>();
++  private final Map<String, List<String>> abstractNames = new HashMap<>();
+ 
+   public StructContext(IResultSaver saver, IDecompiledData decompiledData, LazyLoader loader) {
+     this.saver = saver;
+@@ -188,4 +193,24 @@ public class StructContext {
+   public Map<String, StructClass> getClasses() {
+     return classes;
+   }
++
++  public void loadAbstractMetadata(String string) {
++    for (String line : string.split("\\n")) {
++      String[] pts = line.split(" ");
++      if (pts.length < 4) //class method desc [args...]
++        continue;
++      GenericMethodDescriptor desc = GenericMain.parseMethodSignature(pts[2]);
++      List<String> params = new ArrayList<>();
++      for (int x = 0; x < pts.length - 3; x++) {
++        for (int y = 0; y < desc.params.get(x).stackSize; y++)
++          params.add(pts[x+3]);
++      }
++      this.abstractNames.put(pts[0] + ' ' + pts[1] + ' ' + pts[2], params);
++    }
++  }
++
++  public String renameAbstractParameter(String className, String methodName, String descriptor, int index, String _default) {
++    List<String> params = this.abstractNames.get(className + ' ' + methodName + ' ' + descriptor);
++    return params != null && index < params.size() ? params.get(index) : _default;
++  }
+ }

--- a/FernFlower-Patches/0060-Add-in-iib-option-IGNORE_INVALID_BYTECODE.patch
+++ b/FernFlower-Patches/0060-Add-in-iib-option-IGNORE_INVALID_BYTECODE.patch
@@ -1,0 +1,90 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: sciwhiz12 <sciwhiz12@sciwhiz12.tk>
+Date: Thu, 4 Feb 2021 02:55:14 +0800
+Subject: [PATCH] Add in -iib option; IGNORE_INVALID_BYTECODE
+
+ref: https://github.com/MinecraftForge/FernFlower/commit/c2a6c13d3ccc835ee32d8250f94687bd2712aa40
+
+Upstream has ExprUtil#getSyntheticParametersMask which does not exist here, so had to find all old places before the move to ExprUtil and patched those. (ref: https://github.com/MinecraftForge/FernFlower/commit/8990950daad666f8d9712fdd51ce9ff0d04f5fd7#diff-0d4f70d78fbde518520227007f32404aef3efb8156422c9c7c5b8ab90a39776b)
+
+diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+index 259e5d276e7a98a379bfcf03a18a4b93a92f4396..e16232be3ffdfde57380608ff584079537b2debd 100644
+--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
++++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+@@ -45,6 +45,7 @@ public interface IFernflowerPreferences {
+   String LAMBDA_TO_ANONYMOUS_CLASS = "lac";
+   String BYTECODE_SOURCE_MAPPING = "bsm";
+   String USE_DEBUG_LINE_NUMBERS = "udl";
++  String IGNORE_INVALID_BYTECODE = "iib";
+ 
+   String LOG_LEVEL = "log";
+   String MAX_PROCESSING_METHOD = "mpm";
+@@ -90,6 +91,7 @@ public interface IFernflowerPreferences {
+     put(LAMBDA_TO_ANONYMOUS_CLASS, "0");
+     put(BYTECODE_SOURCE_MAPPING, "0");
+     put(USE_DEBUG_LINE_NUMBERS, "0");
++    put(IGNORE_INVALID_BYTECODE, "0");
+ 
+     put(LOG_LEVEL, IFernflowerLogger.Severity.INFO.name());
+     put(MAX_PROCESSING_METHOD, "0");
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
+index e6152070d2b155d98fc0b8155db12c12ca3864e0..95b3c37273c1460c017fc7b4d94b52d2feea6e27 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
+@@ -371,7 +371,9 @@ public class InvocationExprent extends Exprent {
+ 
+       if (newNode != null) {  // own class
+         if (newNode.getWrapper() != null) {
+-          sigFields = newNode.getWrapper().getMethodWrapper(CodeConstants.INIT_NAME, stringDescriptor).signatureFields;
++          MethodWrapper wrapper = newNode.getWrapper().getMethodWrapper(CodeConstants.INIT_NAME, stringDescriptor);
++          if (wrapper != null || !DecompilerContext.getOption(IFernflowerPreferences.IGNORE_INVALID_BYTECODE))
++            sigFields = wrapper.signatureFields;
+         }
+         else {
+           if (newNode.type == ClassNode.CLASS_MEMBER && (newNode.access & CodeConstants.ACC_STATIC) == 0) { // non-static member class
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
+index 56e67715de8e9fa7c7bf7e341e50d37b0b6b1382..e8376e074749958d779a85f69dde0c7ff8656f87 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
+@@ -22,6 +22,7 @@ import org.jetbrains.java.decompiler.main.DecompilerContext;
+ import org.jetbrains.java.decompiler.main.TextBuffer;
+ import org.jetbrains.java.decompiler.main.collectors.BytecodeMappingTracer;
+ import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
++import org.jetbrains.java.decompiler.main.rels.MethodWrapper;
+ import org.jetbrains.java.decompiler.modules.decompiler.ExprProcessor;
+ import org.jetbrains.java.decompiler.modules.decompiler.vars.CheckTypesResult;
+ import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionPair;
+@@ -180,7 +181,9 @@ public class NewExprent extends Exprent {
+         List<VarVersionPair> sigFields = null;
+         if (newnode != null) { // own class
+           if (newnode.getWrapper() != null) {
+-            sigFields = newnode.getWrapper().getMethodWrapper(CodeConstants.INIT_NAME, invsuper.getStringDescriptor()).signatureFields;
++            MethodWrapper wrapper = newnode.getWrapper().getMethodWrapper(CodeConstants.INIT_NAME, invsuper.getStringDescriptor());
++            if (wrapper != null || !DecompilerContext.getOption(IFernflowerPreferences.IGNORE_INVALID_BYTECODE))
++              sigFields = wrapper.signatureFields;
+           }
+           else {
+             if (newnode.type == ClassNode.CLASS_MEMBER && (newnode.access & CodeConstants.ACC_STATIC) == 0 &&
+@@ -302,7 +305,9 @@ public class NewExprent extends Exprent {
+           List<VarVersionPair> sigFields = null;
+           if (newnode != null) { // own class
+             if (newnode.getWrapper() != null) {
+-              sigFields = newnode.getWrapper().getMethodWrapper(CodeConstants.INIT_NAME, constructor.getStringDescriptor()).signatureFields;
++              MethodWrapper wrapper = newnode.getWrapper().getMethodWrapper(CodeConstants.INIT_NAME, constructor.getStringDescriptor());
++              if (wrapper != null || !DecompilerContext.getOption(IFernflowerPreferences.IGNORE_INVALID_BYTECODE))
++                sigFields = wrapper.signatureFields;
+             }
+             else {
+               if (newnode.type == ClassNode.CLASS_MEMBER && (newnode.access & CodeConstants.ACC_STATIC) == 0 &&
+diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+index e85cd673a627d164a7c168bbf8a19f9a49c22c69..514351caac48358a3c10400dba4ca8bf40db0c6c 100644
+--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
++++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+@@ -27,6 +27,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
+     return new HashMap<String, Object>() {{
+       put(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1");
+       put(IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1");
++      put(IFernflowerPreferences.IGNORE_INVALID_BYTECODE, "1");
+     }};
+   }
+ 


### PR DESCRIPTION
Adds in the patches from master ForgeFlower for the missing required options for MCPConfig.
* Adds `-sef` or `SKIP_EXTRA_FILES` argument.
* Adds `-cfg` argument to specify an external Fernflower configuration file.
* Adds a metadata file for renaming abstract parameters.
* Adds the `-iib` or `IGNORE_INVALID_BYTECODE` argument.