### PR TITLE
Add and reorganize stabilization patches

### DIFF
--- a/FernFlower-Patches/0005-Sort-inner-class-lists-local-variables-variable-defi.patch
+++ b/FernFlower-Patches/0005-Sort-inner-class-lists-local-variables-variable-defi.patch
@@ -40,10 +40,10 @@ index 5a56641c6f614fdf677f8e1900f803f73397867c..b3e9d81eaa3a4d86e4714adf2f8e007a
    }
  }
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/LambdaProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/LambdaProcessor.java
-index 0704efd84bdbd29cb6c9f5db79337147ac0b2be7..809af6d88b5f7c232539e0dbc4c7c8d7c5e26e3b 100644
+index 0704efd84bdbd29cb6c9f5db79337147ac0b2be7..e5f6d7235f27ed41754c534ec758a6c0502a51fa 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/LambdaProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/LambdaProcessor.java
-@@ -119,6 +119,7 @@ public class LambdaProcessor {
+@@ -119,11 +119,14 @@ public class LambdaProcessor {
              }
            }
          }
@@ -51,7 +51,14 @@ index 0704efd84bdbd29cb6c9f5db79337147ac0b2be7..809af6d88b5f7c232539e0dbc4c7c8d7
        }
  
        mt.releaseResources();
-@@ -133,6 +134,7 @@ public class LambdaProcessor {
+     }
+ 
++    Collections.sort(node.nested);
++
+     // build class hierarchy on lambda
+     for (ClassNode nd : node.nested) {
+       if (nd.type == ClassNode.CLASS_LAMBDA) {
+@@ -133,6 +136,7 @@ public class LambdaProcessor {
  
            parent_class.nested.add(nd);
            nd.parent = parent_class;
@@ -71,6 +78,51 @@ index 798010e24206ffcfb76b1f4936f9b5d3709a7275..9aedf22af1f60b3e17752769462aee91
  
          return true;
        }
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
+index c93be38f6abaabfe2704a3fd7c8f0d17a1b9ff52..ac920538381ad0db746f31c1f026c9c6c8883156 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
+@@ -211,7 +211,7 @@ public class DomHelper {
+ 
+     RootStatement root = graphToStatement(graph);
+ 
+-    if (!processStatement(root, new HashMap<Integer, Set<Integer>>())) {
++    if (!processStatement(root, new LinkedHashMap<Integer, Set<Integer>>())) {
+ 
+       //			try {
+       //				DotExporter.toDotFile(root.getFirst().getStats().get(13), new File("c:\\Temp\\stat1.dot"));
+@@ -221,7 +221,7 @@ public class DomHelper {
+       throw new RuntimeException("parsing failure!");
+     }
+ 
+-    LabelHelper.lowContinueLabels(root, new HashSet<StatEdge>());
++    LabelHelper.lowContinueLabels(root, new LinkedHashSet<StatEdge>());
+ 
+     SequenceHelper.condenseSequences(root);
+     root.buildMonitorFlags();
+@@ -486,11 +486,11 @@ public class DomHelper {
+ 
+         boolean same = (post == head);
+ 
+-        HashSet<Statement> setNodes = new HashSet<Statement>();
++        HashSet<Statement> setNodes = new LinkedHashSet<Statement>();
+         HashSet<Statement> setPreds = new HashSet<Statement>();
+ 
+         // collect statement nodes
+-        HashSet<Statement> setHandlers = new HashSet<Statement>();
++        HashSet<Statement> setHandlers = new LinkedHashSet<Statement>();
+         setHandlers.add(head);
+         while (true) {
+ 
+@@ -638,7 +638,7 @@ public class DomHelper {
+               if (setOldNodes.contains(key)) {
+                 Set<Integer> setNew = mapExtPost.get(newid);
+                 if (setNew == null) {
+-                  mapExtPost.put(newid, setNew = new HashSet<Integer>());
++                  mapExtPost.put(newid, setNew = new LinkedHashSet<Integer>());
+                 }
+                 setNew.addAll(set);
+ 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 index 9296bb3f6007bda9647e2f0d919cdfd311567222..205b1876758155132600148f61f641b64e42369c 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
@@ -123,6 +175,99 @@ index 9f1c11b318b128a3bf8dc17e3a6d343ef07800d7..ee8d4cee6cbb439907fb9d9c3f7f61a1
        BasicBlock last = entry.getKey();
  
        if (entry.getValue()) {
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java
+index 26cc638aacb1ae120a4f0000bf224eb01cefe1f1..8ec889c05a77f344d011cb95ab9646a2cd217958 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java
+@@ -33,7 +33,7 @@ public class LabelHelper {
+ 
+     liftClosures(root);
+ 
+-    lowContinueLabels(root, new HashSet<StatEdge>());
++    lowContinueLabels(root, new LinkedHashSet<StatEdge>());
+ 
+     lowClosures(root);
+   }
+@@ -131,7 +131,7 @@ public class LabelHelper {
+         lowContinueLabels(st, edges);
+       }
+       else {
+-        lowContinueLabels(st, new HashSet<StatEdge>());
++        lowContinueLabels(st, new LinkedHashSet<StatEdge>());
+       }
+     }
+   }
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/DominatorTreeExceptionFilter.java b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/DominatorTreeExceptionFilter.java
+index 89e684930084f603339ce2cb067ec9719532110c..1aa61c4c7e866da335ab96177283a702153cb748 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/DominatorTreeExceptionFilter.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/DominatorTreeExceptionFilter.java
+@@ -27,10 +27,10 @@ public class DominatorTreeExceptionFilter {
+   private final Statement statement;
+ 
+   // idom, nodes
+-  private final Map<Integer, Set<Integer>> mapTreeBranches = new HashMap<Integer, Set<Integer>>();
++  private final Map<Integer, Set<Integer>> mapTreeBranches = new LinkedHashMap<Integer, Set<Integer>>();
+ 
+   // handler, range nodes
+-  private final Map<Integer, Set<Integer>> mapExceptionRanges = new HashMap<Integer, Set<Integer>>();
++  private final Map<Integer, Set<Integer>> mapExceptionRanges = new LinkedHashMap<Integer, Set<Integer>>();
+ 
+   // handler, head dom
+   private Map<Integer, Integer> mapExceptionDoms = new HashMap<Integer, Integer>();
+@@ -86,7 +86,7 @@ public class DominatorTreeExceptionFilter {
+ 
+       Set<Integer> set = mapTreeBranches.get(idom);
+       if (set == null) {
+-        mapTreeBranches.put(idom, set = new HashSet<Integer>());
++        mapTreeBranches.put(idom, set = new LinkedHashSet<Integer>());
+       }
+       set.add(key);
+     }
+@@ -101,7 +101,7 @@ public class DominatorTreeExceptionFilter {
+       List<Statement> lstPreds = stat.getNeighbours(StatEdge.TYPE_EXCEPTION, Statement.DIRECTION_BACKWARD);
+       if (!lstPreds.isEmpty()) {
+ 
+-        Set<Integer> set = new HashSet<Integer>();
++        Set<Integer> set = new LinkedHashSet<Integer>();
+ 
+         for (Statement st : lstPreds) {
+           set.add(st.id);
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java
+index 52338f909228f21a19a2a6e31cc734bdbcd024ff..84d1d9bbd2d07a0f18fa0fdcd7dba6e348e33134 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java
+@@ -28,9 +28,9 @@ public class FastExtendedPostdominanceHelper {
+ 
+   private List<Statement> lstReversePostOrderList;
+ 
+-  private HashMap<Integer, FastFixedSet<Integer>> mapSupportPoints = new HashMap<Integer, FastFixedSet<Integer>>();
++  private HashMap<Integer, FastFixedSet<Integer>> mapSupportPoints = new LinkedHashMap<Integer, FastFixedSet<Integer>>();
+ 
+-  private final HashMap<Integer, FastFixedSet<Integer>> mapExtPostdominators = new HashMap<Integer, FastFixedSet<Integer>>();
++  private final HashMap<Integer, FastFixedSet<Integer>> mapExtPostdominators = new LinkedHashMap<Integer, FastFixedSet<Integer>>();
+ 
+   private Statement statement;
+ 
+@@ -40,7 +40,7 @@ public class FastExtendedPostdominanceHelper {
+ 
+     this.statement = statement;
+ 
+-    HashSet<Integer> set = new HashSet<Integer>();
++    HashSet<Integer> set = new LinkedHashSet<Integer>();
+     for (Statement st : statement.getStats()) {
+       set.add(st.id);
+     }
+@@ -67,7 +67,9 @@ public class FastExtendedPostdominanceHelper {
+ 
+     HashMap<Integer, Set<Integer>> res = new HashMap<Integer, Set<Integer>>();
+     for (Entry<Integer, FastFixedSet<Integer>> entry : mapExtPostdominators.entrySet()) {
+-      res.put(entry.getKey(), entry.getValue().toPlainSet());
++      List<Integer> lst = new ArrayList<>(entry.getValue().toPlainSet());
++      Collections.sort(lst);
++      res.put(entry.getKey(), new LinkedHashSet<>(lst));
+     }
+ 
+     return res;
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 index fbd146eca6b7efc4d56e96121a7c6d91748d077c..5f2cb56a85b9ac61141de1c17b457e5847eb8fff 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
@@ -224,6 +369,76 @@ index fbd146eca6b7efc4d56e96121a7c6d91748d077c..5f2cb56a85b9ac61141de1c17b457e58
 +    return ret;
 +  }
  }
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
+index 76a973f9d5813db6c4422b588ec910662dc634a2..2b2167a215106c1024115a9c98b9e67f9cce1ad6 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
+@@ -73,7 +73,7 @@ public class SSAConstructorSparseEx {
+     // DotExporter.toDotFile(dgraph, new File("c:\\Temp\\gr12_my.dot"));
+     // } catch(Exception ex) {ex.printStackTrace();}
+ 
+-    HashSet<Integer> setInit = new HashSet<Integer>();
++    List<Integer> setInit = new ArrayList<Integer>();
+     for (int i = 0; i < 64; i++) {
+       setInit.add(i);
+     }
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
+index 95cefcfeef4cbbd2c6e863ae31efd74ee48cd724..220da75f37dde2eab94c042c0e0929b004e7f8ed 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
+@@ -88,7 +88,7 @@ public class SSAUConstructorSparseEx {
+     FlattenStatementsHelper flatthelper = new FlattenStatementsHelper();
+     DirectGraph dgraph = flatthelper.buildDirectGraph(root);
+ 
+-    HashSet<Integer> setInit = new HashSet<Integer>();
++    List<Integer> setInit = new ArrayList<Integer>();
+     for (int i = 0; i < 64; i++) {
+       setInit.add(i);
+     }
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java
+index 4f22cf710a67e5f0d69951fb4bee6fa194e5a4ea..c0455987e9e8c7d2c99c155f997d378179dcb4c8 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java
+@@ -20,7 +20,8 @@ import org.jetbrains.java.decompiler.main.collectors.BytecodeMappingTracer;
+ 
+ import java.util.Collection;
+ import java.util.HashSet;
+-
++import java.util.LinkedHashSet;
++import java.util.Set;
+ 
+ public class GeneralStatement extends Statement {
+ 
+@@ -39,7 +40,7 @@ public class GeneralStatement extends Statement {
+     first = head;
+     stats.addWithKey(head, head.id);
+ 
+-    HashSet<Statement> set = new HashSet<Statement>(statements);
++    Set<Statement> set = new LinkedHashSet<Statement>(statements);
+     set.remove(head);
+ 
+     for (Statement st : set) {
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
+index 59164900d91a1d02526de1ab32958fac7083357b..97880cd0c8c820f5a157a6e206d7156f7433aa56 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
+@@ -75,7 +75,15 @@ public class SwitchStatement extends Statement {
+ 
+     default_edge = head.getSuccessorEdges(Statement.STATEDGE_DIRECT_ALL).get(0);
+ 
+-    for (Statement st : lstNodes) {
++    // We need to use set above in case we have multiple edges to the same node. But HashSets iterator is not ordered, so sort
++    List<Statement> sorted = new ArrayList<>(lstNodes);
++    Collections.sort(sorted, new Comparator<Statement>() {
++      @Override
++      public int compare(Statement o1, Statement o2) {
++        return o1.id - o2.id;
++      }
++    });
++    for (Statement st : sorted) {
+       stats.addWithKey(st, st.id);
+     }
+   }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
 index 31f0f86d4423ac537faf31b7f16833f263801b23..4751052a5468ffc469d7166bce648d5b658e040d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java

--- a/FernFlower-Patches/0013-Add-enhanced-for-each-loop-detection-re-introduce-Do.patch
+++ b/FernFlower-Patches/0013-Add-enhanced-for-each-loop-detection-re-introduce-Do.patch
@@ -539,7 +539,7 @@ index 971ace503b1289a07195289a8e951ae192d9123a..d88480ef7133b0c27ff18518599127ec
  
                  DirectNode nodeinc = new DirectNode(DirectNode.NODE_INCREMENT, stat, stat.id + "_inc");
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
-index 76a973f9d5813db6c4422b588ec910662dc634a2..7f4118cd58c31d58c3715e67bbe2ad8f227da8b8 100644
+index 2b2167a215106c1024115a9c98b9e67f9cce1ad6..ea50bd65b736dfd71f65de2e635330b0ce8db0a6 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
 @@ -59,6 +59,7 @@ public class SSAConstructorSparseEx {
@@ -550,7 +550,7 @@ index 76a973f9d5813db6c4422b588ec910662dc634a2..7f4118cd58c31d58c3715e67bbe2ad8f
    private final List<VarVersionPair> startVars = new ArrayList<VarVersionPair>();
  
    // set factory
-@@ -69,11 +70,9 @@ public class SSAConstructorSparseEx {
+@@ -69,9 +70,7 @@ public class SSAConstructorSparseEx {
      FlattenStatementsHelper flatthelper = new FlattenStatementsHelper();
      DirectGraph dgraph = flatthelper.buildDirectGraph(root);
  
@@ -559,11 +559,8 @@ index 76a973f9d5813db6c4422b588ec910662dc634a2..7f4118cd58c31d58c3715e67bbe2ad8f
 -    // } catch(Exception ex) {ex.printStackTrace();}
 +    org.jetbrains.java.decompiler.util.DotExporter.toDotFile(dgraph, mt, "ssaSplitVariables");
  
--    HashSet<Integer> setInit = new HashSet<Integer>();
-+    List<Integer> setInit = new ArrayList<Integer>(); //Important: HashSets have undefined order, so use a ordered list.
+     List<Integer> setInit = new ArrayList<Integer>();
      for (int i = 0; i < 64; i++) {
-       setInit.add(i);
-     }
 @@ -84,20 +83,19 @@ public class SSAConstructorSparseEx {
  
      setCatchMaps(root, dgraph, flatthelper);
@@ -598,21 +595,18 @@ index 76a973f9d5813db6c4422b588ec910662dc634a2..7f4118cd58c31d58c3715e67bbe2ad8f
      return startVars;
    }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
-index 95cefcfeef4cbbd2c6e863ae31efd74ee48cd724..9ba8195cd90a7d7c78fca7fa28cf7370d319768c 100644
+index 220da75f37dde2eab94c042c0e0929b004e7f8ed..94b4cbac5f02ace7ba2f1505fdb6794b182312f5 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
-@@ -88,7 +88,9 @@ public class SSAUConstructorSparseEx {
-     FlattenStatementsHelper flatthelper = new FlattenStatementsHelper();
+@@ -89,6 +89,7 @@ public class SSAUConstructorSparseEx {
      DirectGraph dgraph = flatthelper.buildDirectGraph(root);
  
--    HashSet<Integer> setInit = new HashSet<Integer>();
+     List<Integer> setInit = new ArrayList<Integer>();
 +    org.jetbrains.java.decompiler.util.DotExporter.toDotFile(dgraph, mt, "ssauSplitVariables");
-+
-+    List<Integer> setInit = new ArrayList<Integer>(); //Important: HashSets have undefined order, so use a ordered list.
      for (int i = 0; i < 64; i++) {
        setInit.add(i);
      }
-@@ -98,25 +100,25 @@ public class SSAUConstructorSparseEx {
+@@ -98,25 +99,25 @@ public class SSAUConstructorSparseEx {
  
      setCatchMaps(root, dgraph, flatthelper);
  

--- a/FernFlower-Patches/0023-Change-begin-end-detection.-Less-derpy.patch
+++ b/FernFlower-Patches/0023-Change-begin-end-detection.-Less-derpy.patch
@@ -196,7 +196,7 @@ index c12605070b1de0bd65ebed44eacb25467666efbc..f71ed84bc4ad195a97b4c535f21b55a9
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
-index 59164900d91a1d02526de1ab32958fac7083357b..3e272016903de00ee47c55fad62db4b0687a04b5 100644
+index 97880cd0c8c820f5a157a6e206d7156f7433aa56..f4acbd4fb624b6d818fa78cdbdbe2f39ad1dc9aa 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
 @@ -27,6 +27,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.StatEdge;
@@ -207,7 +207,7 @@ index 59164900d91a1d02526de1ab32958fac7083357b..3e272016903de00ee47c55fad62db4b0
  import org.jetbrains.java.decompiler.struct.gen.VarType;
  
  import java.util.*;
-@@ -365,4 +366,15 @@ public class SwitchStatement extends Statement {
+@@ -373,4 +374,15 @@ public class SwitchStatement extends Statement {
    public List<List<ConstExprent>> getCaseValues() {
      return caseValues;
    }

--- a/FernFlower-Patches/0034-Loosen-up-LoopExtractHelper-to-include-extractable-b.patch
+++ b/FernFlower-Patches/0034-Loosen-up-LoopExtractHelper-to-include-extractable-b.patch
@@ -138,7 +138,7 @@ index ef7e97a5e99899896b11376fd31e3511fb5b06b5..eca34134bf72cb0ddc9e3b245ca38474
        return sb.toString();
    }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
-index c93be38f6abaabfe2704a3fd7c8f0d17a1b9ff52..67d16d5c139033d4774acc22c54b8866594c3ec5 100644
+index ac920538381ad0db746f31c1f026c9c6c8883156..e044890242dd7998a4414ac44da2ec045fed88a8 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
 @@ -20,9 +20,12 @@ import org.jetbrains.java.decompiler.code.cfg.ControlFlowGraph;
@@ -154,7 +154,7 @@ index c93be38f6abaabfe2704a3fd7c8f0d17a1b9ff52..67d16d5c139033d4774acc22c54b8866
  import org.jetbrains.java.decompiler.util.FastFixedSetFactory;
  import org.jetbrains.java.decompiler.util.FastFixedSetFactory.FastFixedSet;
  import org.jetbrains.java.decompiler.util.InterpreterUtil;
-@@ -207,17 +210,11 @@ public class DomHelper {
+@@ -207,17 +210,12 @@ public class DomHelper {
      return ret;
    }
  
@@ -162,8 +162,8 @@ index c93be38f6abaabfe2704a3fd7c8f0d17a1b9ff52..67d16d5c139033d4774acc22c54b8866
 +  public static RootStatement parseGraph(ControlFlowGraph graph, StructMethod mt) {
  
      RootStatement root = graphToStatement(graph);
--
-     if (!processStatement(root, new HashMap<Integer, Set<Integer>>())) {
+ 
+     if (!processStatement(root, new LinkedHashMap<Integer, Set<Integer>>())) {
 -
 -      //			try {
 -      //				DotExporter.toDotFile(root.getFirst().getStats().get(13), new File("c:\\Temp\\stat1.dot"));

--- a/FernFlower-Patches/0043-Enhance-switches-on-enums.patch
+++ b/FernFlower-Patches/0043-Enhance-switches-on-enums.patch
@@ -179,7 +179,7 @@ index 33785497b358346846ce58824ce3c2f0aa2be815..1eaeaa6519574c4defe41c789743631f
  
      if (child.lambdaInformation.is_method_reference) { // method reference, no code and no parameters
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
-index 3e272016903de00ee47c55fad62db4b0687a04b5..f8eec64ce7edbb2ff9e4d76c7d9e59c42060e57f 100644
+index f4acbd4fb624b6d818fa78cdbdbe2f39ad1dc9aa..fec1d7552348fca1d200e164219f1cf542c2c3ad 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
 @@ -24,10 +24,14 @@ import org.jetbrains.java.decompiler.main.collectors.CounterContainer;
@@ -197,7 +197,7 @@ index 3e272016903de00ee47c55fad62db4b0687a04b5..f8eec64ce7edbb2ff9e4d76c7d9e59c4
  import org.jetbrains.java.decompiler.struct.gen.VarType;
  
  import java.util.*;
-@@ -118,7 +122,12 @@ public class SwitchStatement extends Statement {
+@@ -126,7 +130,12 @@ public class SwitchStatement extends Statement {
        tracer.incrementCurrentSourceLine();
      }
  
@@ -211,7 +211,7 @@ index 3e272016903de00ee47c55fad62db4b0687a04b5..f8eec64ce7edbb2ff9e4d76c7d9e59c4
      tracer.incrementCurrentSourceLine();
  
      VarType switch_type = headexprent.get(0).getExprType();
-@@ -138,7 +147,14 @@ public class SwitchStatement extends Statement {
+@@ -146,7 +155,14 @@ public class SwitchStatement extends Statement {
            ConstExprent value = (ConstExprent)values.get(j).copy();
            value.setConstType(switch_type);
  
@@ -227,7 +227,7 @@ index 3e272016903de00ee47c55fad62db4b0687a04b5..f8eec64ce7edbb2ff9e4d76c7d9e59c4
            tracer.incrementCurrentSourceLine();
          }
        }
-@@ -152,6 +168,41 @@ public class SwitchStatement extends Statement {
+@@ -160,6 +176,41 @@ public class SwitchStatement extends Statement {
      return buf;
    }
  

--- a/FernFlower-Patches/0047-Deterministic-label-names-based-on-jvm-instruction-i.patch
+++ b/FernFlower-Patches/0047-Deterministic-label-names-based-on-jvm-instruction-i.patch
@@ -58,10 +58,10 @@ index acc74a60fd6a90ad15959f6c3164757390542ada..6636d1dab67c0ad87b98fd6b9ebfeca7
      }
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java
-index 4f22cf710a67e5f0d69951fb4bee6fa194e5a4ea..499894a572629a0e14aba0ebfae4929d6e0eec18 100644
+index c0455987e9e8c7d2c99c155f997d378179dcb4c8..dc9789593e86b85d293c7620e4255fa9bafe3e81 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java
-@@ -57,7 +57,7 @@ public class GeneralStatement extends Statement {
+@@ -58,7 +58,7 @@ public class GeneralStatement extends Statement {
      TextBuffer buf = new TextBuffer();
  
      if (isLabeled()) {
@@ -106,10 +106,10 @@ index 7d2ee435ce1c153b6da410d825d697d9790e35fe..92588febd470b2cf9db2d9f7ff3ae4e2
      }
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
-index f8eec64ce7edbb2ff9e4d76c7d9e59c42060e57f..2a2930908a9051cea5f590d0a6e66d38689d1753 100644
+index fec1d7552348fca1d200e164219f1cf542c2c3ad..1624ce778d827671f916cc822335febaa1df60cf 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
-@@ -118,7 +118,7 @@ public class SwitchStatement extends Statement {
+@@ -126,7 +126,7 @@ public class SwitchStatement extends Statement {
      buf.append(first.toJava(indent, tracer));
  
      if (isLabeled()) {

--- a/FernFlower-Patches/0049-More-move-from-HashSet-to-LinkedHashSet-to-stabelize.patch
+++ b/FernFlower-Patches/0049-More-move-from-HashSet-to-LinkedHashSet-to-stabelize.patch
@@ -6,25 +6,19 @@ Subject: [PATCH] More move from HashSet to LinkedHashSet to stabelize
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
-index 67d16d5c139033d4774acc22c54b8866594c3ec5..c45f5e06dba0607232dd1fac4c089a22ceeede7b 100644
+index e044890242dd7998a4414ac44da2ec045fed88a8..7434b14c7c6d2d9ff2a10f66c9da848cf25b3a9e 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
-@@ -213,12 +213,12 @@ public class DomHelper {
-   public static RootStatement parseGraph(ControlFlowGraph graph, StructMethod mt) {
+@@ -214,7 +214,7 @@ public class DomHelper {
  
      RootStatement root = graphToStatement(graph);
--    if (!processStatement(root, new HashMap<Integer, Set<Integer>>())) {
-+    if (!processStatement(root, new HashMap<Integer, LinkedHashSet<Integer>>())) {
+ 
+-    if (!processStatement(root, new LinkedHashMap<Integer, Set<Integer>>())) {
++    if (!processStatement(root, new LinkedHashMap<Integer, LinkedHashSet<Integer>>())) {
        DotExporter.toDotFile(graph, mt, "parseGraphFail", true);
        throw new RuntimeException("parsing failure!");
      }
- 
--    LabelHelper.lowContinueLabels(root, new HashSet<StatEdge>());
-+    LabelHelper.lowContinueLabels(root, new LinkedHashSet<StatEdge>());
- 
-     SequenceHelper.condenseSequences(root);
-     root.buildMonitorFlags();
-@@ -309,7 +309,7 @@ public class DomHelper {
+@@ -310,7 +310,7 @@ public class DomHelper {
      }
    }
  
@@ -33,7 +27,7 @@ index 67d16d5c139033d4774acc22c54b8866594c3ec5..c45f5e06dba0607232dd1fac4c089a22
  
      if (general.type == Statement.TYPE_ROOT) {
        Statement stat = general.getFirst();
-@@ -358,7 +358,7 @@ public class DomHelper {
+@@ -359,7 +359,7 @@ public class DomHelper {
            //						DotExporter.toDotFile(general, new File("c:\\Temp\\stat1.dot"));
            //					} catch(Exception ex) {ex.printStackTrace();}
  
@@ -42,7 +36,7 @@ index 67d16d5c139033d4774acc22c54b8866594c3ec5..c45f5e06dba0607232dd1fac4c089a22
            mapRefreshed = true;
          }
  
-@@ -379,7 +379,7 @@ public class DomHelper {
+@@ -380,7 +380,7 @@ public class DomHelper {
              Statement stat = findGeneralStatement(general, forceall, mapExtPost);
  
              if (stat != null) {
@@ -51,7 +45,7 @@ index 67d16d5c139033d4774acc22c54b8866594c3ec5..c45f5e06dba0607232dd1fac4c089a22
  
                if (complete) {
                  // replace general purpose statement with simple one
-@@ -389,7 +389,7 @@ public class DomHelper {
+@@ -390,7 +390,7 @@ public class DomHelper {
                  return false;
                }
  
@@ -60,7 +54,7 @@ index 67d16d5c139033d4774acc22c54b8866594c3ec5..c45f5e06dba0607232dd1fac4c089a22
                mapRefreshed = true;
                reducibility = 0;
              }
-@@ -410,14 +410,14 @@ public class DomHelper {
+@@ -411,14 +411,14 @@ public class DomHelper {
          break;
        }
        else {
@@ -77,7 +71,7 @@ index 67d16d5c139033d4774acc22c54b8866594c3ec5..c45f5e06dba0607232dd1fac4c089a22
  
      VBStyleCollection<Statement, Integer> stats = stat.getStats();
      VBStyleCollection<List<Integer>, Integer> vbPost;
-@@ -595,7 +595,7 @@ public class DomHelper {
+@@ -596,7 +596,7 @@ public class DomHelper {
      return true;
    }
  
@@ -86,19 +80,16 @@ index 67d16d5c139033d4774acc22c54b8866594c3ec5..c45f5e06dba0607232dd1fac4c089a22
  
      boolean found, success = false;
  
-@@ -633,9 +633,9 @@ public class DomHelper {
+@@ -634,7 +634,7 @@ public class DomHelper {
                set.removeAll(setOldNodes);
  
                if (setOldNodes.contains(key)) {
 -                Set<Integer> setNew = mapExtPost.get(newid);
 +                LinkedHashSet<Integer> setNew = mapExtPost.get(newid);
                  if (setNew == null) {
--                  mapExtPost.put(newid, setNew = new HashSet<Integer>());
-+                  mapExtPost.put(newid, setNew = new LinkedHashSet<Integer>());
+                   mapExtPost.put(newid, setNew = new LinkedHashSet<Integer>());
                  }
-                 setNew.addAll(set);
- 
-@@ -666,7 +666,6 @@ public class DomHelper {
+@@ -667,7 +667,6 @@ public class DomHelper {
  
  
    private static Statement detectStatement(Statement head) {
@@ -107,18 +98,9 @@ index 67d16d5c139033d4774acc22c54b8866594c3ec5..c45f5e06dba0607232dd1fac4c089a22
  
      if ((res = DoStatement.isHead(head)) != null) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java
-index 26cc638aacb1ae120a4f0000bf224eb01cefe1f1..9bf29358c5c3c36c1fa69198ad17587a21d66823 100644
+index 8ec889c05a77f344d011cb95ab9646a2cd217958..9bf29358c5c3c36c1fa69198ad17587a21d66823 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java
-@@ -33,7 +33,7 @@ public class LabelHelper {
- 
-     liftClosures(root);
- 
--    lowContinueLabels(root, new HashSet<StatEdge>());
-+    lowContinueLabels(root, new LinkedHashSet<StatEdge>());
- 
-     lowClosures(root);
-   }
 @@ -99,7 +99,7 @@ public class LabelHelper {
      }
    }
@@ -128,17 +110,8 @@ index 26cc638aacb1ae120a4f0000bf224eb01cefe1f1..9bf29358c5c3c36c1fa69198ad17587a
  
      boolean ok = (stat.type != Statement.TYPE_DO);
      if (!ok) {
-@@ -131,7 +131,7 @@ public class LabelHelper {
-         lowContinueLabels(st, edges);
-       }
-       else {
--        lowContinueLabels(st, new HashSet<StatEdge>());
-+        lowContinueLabels(st, new LinkedHashSet<StatEdge>());
-       }
-     }
-   }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java
-index 52338f909228f21a19a2a6e31cc734bdbcd024ff..eee7b15dc347c9582f49f13c41106f76ff14b064 100644
+index 84d1d9bbd2d07a0f18fa0fdcd7dba6e348e33134..3fd6bf4d788b9110f362d477ee273057d18ae819 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java
 @@ -36,7 +36,7 @@ public class FastExtendedPostdominanceHelper {
@@ -150,21 +123,16 @@ index 52338f909228f21a19a2a6e31cc734bdbcd024ff..eee7b15dc347c9582f49f13c41106f76
  
      this.statement = statement;
  
-@@ -65,9 +65,11 @@ public class FastExtendedPostdominanceHelper {
+@@ -65,7 +65,7 @@ public class FastExtendedPostdominanceHelper {
  
      filterOnDominance(filter);
  
 -    HashMap<Integer, Set<Integer>> res = new HashMap<Integer, Set<Integer>>();
 +    HashMap<Integer, LinkedHashSet<Integer>> res = new HashMap<Integer, LinkedHashSet<Integer>>();
      for (Entry<Integer, FastFixedSet<Integer>> entry : mapExtPostdominators.entrySet()) {
--      res.put(entry.getKey(), entry.getValue().toPlainSet());
-+      List<Integer> lst =  new ArrayList<Integer>(entry.getValue().toPlainSet());
-+      Collections.sort(lst); // Order matters!
-+      res.put(entry.getKey(), new LinkedHashSet<Integer>(lst));
-     }
- 
-     return res;
-@@ -91,7 +93,7 @@ public class FastExtendedPostdominanceHelper {
+       List<Integer> lst = new ArrayList<>(entry.getValue().toPlainSet());
+       Collections.sort(lst);
+@@ -93,7 +93,7 @@ public class FastExtendedPostdominanceHelper {
        Set<Statement> setVisited = new HashSet<Statement>();
  
        setVisited.add(stack.getFirst());
@@ -173,7 +141,7 @@ index 52338f909228f21a19a2a6e31cc734bdbcd024ff..eee7b15dc347c9582f49f13c41106f76
        while (!stack.isEmpty()) {
  
          Statement stat = stack.removeFirst();
-@@ -109,17 +111,17 @@ public class FastExtendedPostdominanceHelper {
+@@ -111,17 +111,17 @@ public class FastExtendedPostdominanceHelper {
            setPostdoms.complement(path);
            continue;
          }

--- a/FernFlower-Patches/0052-Stabelize-a-few-areas-on-Java-8.-Notibly-the-exit-ma.patch
+++ b/FernFlower-Patches/0052-Stabelize-a-few-areas-on-Java-8.-Notibly-the-exit-ma.patch
@@ -31,113 +31,36 @@ index 16d778867677249c16b38fcfbca16618b1fa4ac0..9bcd3ba461d73cb139bca4fc0756130d
          System.out.print(" t:"+((DoStatement)statement).getLooptype());
      } else if (statement.type == Statement.TYPE_BASICBLOCK) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
-index c45f5e06dba0607232dd1fac4c089a22ceeede7b..e780bd6642f5ebca0af8971bb209630e44bb3b0a 100644
+index 7434b14c7c6d2d9ff2a10f66c9da848cf25b3a9e..3c5a86d8ecb45644c65b4507cdf87d91b8aaa1c3 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
-@@ -483,11 +483,11 @@ public class DomHelper {
+@@ -484,7 +484,7 @@ public class DomHelper {
  
          boolean same = (post == head);
  
--        HashSet<Statement> setNodes = new HashSet<Statement>();
+-        HashSet<Statement> setNodes = new LinkedHashSet<Statement>();
 +        LinkedHashSet<Statement> setNodes = new LinkedHashSet<Statement>();
          HashSet<Statement> setPreds = new HashSet<Statement>();
  
          // collect statement nodes
--        HashSet<Statement> setHandlers = new HashSet<Statement>();
-+        HashSet<Statement> setHandlers = new LinkedHashSet<Statement>();
-         setHandlers.add(head);
-         while (true) {
- 
-diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/DominatorTreeExceptionFilter.java b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/DominatorTreeExceptionFilter.java
-index 89e684930084f603339ce2cb067ec9719532110c..1c3a8e13df680240d0a6638115bf9a7f6982b5c9 100644
---- a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/DominatorTreeExceptionFilter.java
-+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/DominatorTreeExceptionFilter.java
-@@ -27,10 +27,10 @@ public class DominatorTreeExceptionFilter {
-   private final Statement statement;
- 
-   // idom, nodes
--  private final Map<Integer, Set<Integer>> mapTreeBranches = new HashMap<Integer, Set<Integer>>();
-+  private final Map<Integer, Set<Integer>> mapTreeBranches = new LinkedHashMap<Integer, Set<Integer>>();
- 
-   // handler, range nodes
--  private final Map<Integer, Set<Integer>> mapExceptionRanges = new HashMap<Integer, Set<Integer>>();
-+  private final Map<Integer, Set<Integer>> mapExceptionRanges = new LinkedHashMap<Integer, Set<Integer>>();
- 
-   // handler, head dom
-   private Map<Integer, Integer> mapExceptionDoms = new HashMap<Integer, Integer>();
-@@ -86,7 +86,7 @@ public class DominatorTreeExceptionFilter {
- 
-       Set<Integer> set = mapTreeBranches.get(idom);
-       if (set == null) {
--        mapTreeBranches.put(idom, set = new HashSet<Integer>());
-+        mapTreeBranches.put(idom, set = new LinkedHashSet<Integer>());
-       }
-       set.add(key);
-     }
-diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java
-index eee7b15dc347c9582f49f13c41106f76ff14b064..349f522b2fe170c57b55d4812cbc56086f6a1502 100644
---- a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java
-+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java
-@@ -28,9 +28,9 @@ public class FastExtendedPostdominanceHelper {
- 
-   private List<Statement> lstReversePostOrderList;
- 
--  private HashMap<Integer, FastFixedSet<Integer>> mapSupportPoints = new HashMap<Integer, FastFixedSet<Integer>>();
-+  private HashMap<Integer, FastFixedSet<Integer>> mapSupportPoints = new LinkedHashMap<Integer, FastFixedSet<Integer>>();
- 
--  private final HashMap<Integer, FastFixedSet<Integer>> mapExtPostdominators = new HashMap<Integer, FastFixedSet<Integer>>();
-+  private final HashMap<Integer, FastFixedSet<Integer>> mapExtPostdominators = new LinkedHashMap<Integer, FastFixedSet<Integer>>();
- 
-   private Statement statement;
- 
-@@ -40,7 +40,7 @@ public class FastExtendedPostdominanceHelper {
- 
-     this.statement = statement;
- 
--    HashSet<Integer> set = new HashSet<Integer>();
-+    HashSet<Integer> set = new LinkedHashSet<Integer>();
-     for (Statement st : statement.getStats()) {
-       set.add(st.id);
-     }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java
-index 499894a572629a0e14aba0ebfae4929d6e0eec18..f7e00804a046ad4992f918396b9ca53c6872b01c 100644
+index dc9789593e86b85d293c7620e4255fa9bafe3e81..722d6cb6c9ad3d18212e127787287d9fc504ad7d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java
-@@ -20,6 +20,7 @@ import org.jetbrains.java.decompiler.main.collectors.BytecodeMappingTracer;
- 
+@@ -21,7 +21,6 @@ import org.jetbrains.java.decompiler.main.collectors.BytecodeMappingTracer;
  import java.util.Collection;
  import java.util.HashSet;
-+import java.util.LinkedHashSet;
- 
+ import java.util.LinkedHashSet;
+-import java.util.Set;
  
  public class GeneralStatement extends Statement {
-@@ -39,7 +40,7 @@ public class GeneralStatement extends Statement {
+ 
+@@ -40,7 +39,7 @@ public class GeneralStatement extends Statement {
      first = head;
      stats.addWithKey(head, head.id);
  
--    HashSet<Statement> set = new HashSet<Statement>(statements);
+-    Set<Statement> set = new LinkedHashSet<Statement>(statements);
 +    LinkedHashSet<Statement> set = new LinkedHashSet<Statement>(statements);
      set.remove(head);
  
      for (Statement st : set) {
-diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
-index 2a2930908a9051cea5f590d0a6e66d38689d1753..af522d97a6198ba50a5eae7b69232d9e4ac5eec6 100644
---- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
-+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
-@@ -80,7 +80,15 @@ public class SwitchStatement extends Statement {
- 
-     default_edge = head.getSuccessorEdges(Statement.STATEDGE_DIRECT_ALL).get(0);
- 
--    for (Statement st : lstNodes) {
-+    //We need to use set above in case we have multiple edges to the same node. But HashSets iterator is not ordered, so sort
-+    List<Statement> sorted = new ArrayList<Statement>(lstNodes);
-+    Collections.sort(sorted, new Comparator<Statement>() {
-+      @Override
-+      public int compare(Statement o1, Statement o2) {
-+        return o1.id - o2.id;
-+      }
-+    });
-+    for (Statement st : sorted) {
-       stats.addWithKey(st, st.id);
-     }
-   }


### PR DESCRIPTION
Added more of the stabilization patching from master ForgeFlower into the main stabilization patch in Legacy-2.0. Further patches down the line are affected because their (conflicting) stabilization patches were also moved into the main stabilization patch.

Here's to hoping that this is a step towards fixing the TextureManager and Cartesian patching errors.