### PR TITLE
test: Add Comparison Test against FG2 Output

### DIFF
--- a/FernFlower-Patches/0065-Add-Decompilation-Test-comparing-output-with-old-FG2.patch
+++ b/FernFlower-Patches/0065-Add-Decompilation-Test-comparing-output-with-old-FG2.patch
@@ -1,0 +1,114 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: AterAnimAvis <AterAnimAvis@gmail.com>
+Date: Mon, 17 May 2021 19:32:29 +0100
+Subject: [PATCH] Add Decompilation Test comparing output with old FG2
+
+Signed-off-by: AterAnimAvis <AterAnimAvis@gmail.com>
+
+diff --git a/test/org/jetbrains/java/decompiler/RetroGradleComparisonTest.java b/test/org/jetbrains/java/decompiler/RetroGradleComparisonTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..e140ad56cb4efba2c10c213388befb22bb1f7a15
+--- /dev/null
++++ b/test/org/jetbrains/java/decompiler/RetroGradleComparisonTest.java
+@@ -0,0 +1,101 @@
++package org.jetbrains.java.decompiler;
++
++import java.io.IOException;
++import java.io.InputStream;
++import java.io.OutputStream;
++import java.nio.file.Files;
++import java.nio.file.Path;
++import java.nio.file.Paths;
++import java.util.HashMap;
++import java.util.zip.ZipEntry;
++import java.util.zip.ZipInputStream;
++import java.util.zip.ZipOutputStream;
++
++import org.junit.After;
++import org.junit.Before;
++import org.junit.Test;
++import codechicken.diffpatch.cli.CliOperation;
++import codechicken.diffpatch.cli.DiffOperation;
++import codechicken.diffpatch.util.Utils;
++
++import static org.junit.Assert.assertEquals;
++import static org.junit.Assert.fail;
++
++public class RetroGradleComparisonTest {
++
++    protected DecompilerTestFixture fixture;
++
++    @Before
++    public void setUp() throws IOException {
++        fixture = new DecompilerTestFixture();
++        fixture.setUp(new HashMap<>()); //TODO:
++    }
++
++    @After
++    public void tearDown() {
++        fixture.tearDown();
++        fixture = null;
++    }
++
++    Path fg2output   = Paths.get("testData", "retrogradle", "fg2/decompiled.zip");
++    Path fg2filtered = Paths.get("testData", "retrogradle", "fg2/decompiled-filtered.zip");
++    Path fg3input    = Paths.get("testData", "retrogradle", "fg3/output.jar");
++    Path diffOutput  = Paths.get("testData", "retrogradle", "output");
++
++    /**
++     * Setup Required: <br>
++     * <br>
++     * - clone 1.11.x (FG2) from <a href="https://github.com/RetroGradle/MinecraftForge">RetroGradle/MinecraftForge</a><br>
++     * - `gradlew setup` (May need to be from the terminal due to gradle version) <br>
++     * - copy `build/localCache/decompiled.zip` -> `testData/retrogradle/fg2/decompiled.zip` <br>
++     * <br>
++     * - checkout retrogradle1.11 branch <br>
++     * - `gradlew setup` (May require a second `gradlew setup` as the first downloads the custom MCPConfig zip) <br>
++     * - copy `projects/mcp/build/mcp/decompile/output.jar` -> `testData/retrogradle/fg3/output.jar` <br>
++     */
++    @Test
++    public void diffOutputs() throws IOException {
++        if (Files.exists(diffOutput)) Utils.deleteFolder(diffOutput);
++        Files.createDirectories(diffOutput);
++
++        if (!Files.exists(fg2output)) fail("FG2 1.11.x decompiled.zip not provided");
++        if (!Files.exists(fg3input))  fail("Retrogradle 1.11.x output.jar not provided");
++
++        // We have to filter the fg2output to only contain the java files like fg3 does
++        filter(fg2output, fg2filtered);
++
++        final CliOperation.Result<DiffOperation.DiffSummary> result = DiffOperation.builder()
++            .aPrefix("fg2")
++            .bPrefix("fg3")
++            .aPath(fg2filtered)
++            .bPath(fg3input)
++            .outputPath(diffOutput)
++            .logTo(System.out)
++            .verbose(false)
++            .summary(true) // Summary is fairly useful in testing
++            .build()
++            .operate();
++
++        assertEquals(2, result.summary.removedFiles); // Side & SideOnly aren't present in the FG3 zip
++        assertEquals(0, result.summary.changedFiles); // Otherwise we expect 0 differences with FG2 zip
++        assertEquals(0, result.summary.addedFiles);
++    }
++
++    private static void filter(Path input, Path output) throws IOException {
++        if (Files.exists(output)) return;
++
++        filter(Files.newInputStream(input), Files.newOutputStream(output));
++    }
++
++    private static void filter(InputStream input, OutputStream output) throws IOException {
++        try (ZipOutputStream zout = new ZipOutputStream(output); ZipInputStream zin = new ZipInputStream(input)) {
++            ZipEntry entry;
++            while ((entry = zin.getNextEntry()) != null) {
++                if (entry.getName().endsWith(".java")) {
++                    zout.putNextEntry(entry);
++                    Utils.copy(zin, zout);
++                }
++            }
++        }
++    }
++}

--- a/FernFlower-Patches/0065-Add-Decompilation-Test-comparing-output-with-old-FG2.patch
+++ b/FernFlower-Patches/0065-Add-Decompilation-Test-comparing-output-with-old-FG2.patch
@@ -3,7 +3,6 @@ From: AterAnimAvis <AterAnimAvis@gmail.com>
 Date: Mon, 17 May 2021 19:32:29 +0100
 Subject: [PATCH] Add Decompilation Test comparing output with old FG2
 
-Signed-off-by: AterAnimAvis <AterAnimAvis@gmail.com>
 
 diff --git a/test/org/jetbrains/java/decompiler/RetroGradleComparisonTest.java b/test/org/jetbrains/java/decompiler/RetroGradleComparisonTest.java
 new file mode 100644

--- a/FernFlower-Patches/0065-Add-Decompilation-Test-comparing-output-with-old-FG2.patch
+++ b/FernFlower-Patches/0065-Add-Decompilation-Test-comparing-output-with-old-FG2.patch
@@ -7,10 +7,10 @@ Signed-off-by: AterAnimAvis <AterAnimAvis@gmail.com>
 
 diff --git a/test/org/jetbrains/java/decompiler/RetroGradleComparisonTest.java b/test/org/jetbrains/java/decompiler/RetroGradleComparisonTest.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e140ad56cb4efba2c10c213388befb22bb1f7a15
+index 0000000000000000000000000000000000000000..601fdde223bbeb3f028bd8719f244ebbecf5dcab
 --- /dev/null
 +++ b/test/org/jetbrains/java/decompiler/RetroGradleComparisonTest.java
-@@ -0,0 +1,101 @@
+@@ -0,0 +1,84 @@
 +package org.jetbrains.java.decompiler;
 +
 +import java.io.IOException;
@@ -19,13 +19,10 @@ index 0000000000000000000000000000000000000000..e140ad56cb4efba2c10c213388befb22
 +import java.nio.file.Files;
 +import java.nio.file.Path;
 +import java.nio.file.Paths;
-+import java.util.HashMap;
 +import java.util.zip.ZipEntry;
 +import java.util.zip.ZipInputStream;
 +import java.util.zip.ZipOutputStream;
 +
-+import org.junit.After;
-+import org.junit.Before;
 +import org.junit.Test;
 +import codechicken.diffpatch.cli.CliOperation;
 +import codechicken.diffpatch.cli.DiffOperation;
@@ -35,20 +32,6 @@ index 0000000000000000000000000000000000000000..e140ad56cb4efba2c10c213388befb22
 +import static org.junit.Assert.fail;
 +
 +public class RetroGradleComparisonTest {
-+
-+    protected DecompilerTestFixture fixture;
-+
-+    @Before
-+    public void setUp() throws IOException {
-+        fixture = new DecompilerTestFixture();
-+        fixture.setUp(new HashMap<>()); //TODO:
-+    }
-+
-+    @After
-+    public void tearDown() {
-+        fixture.tearDown();
-+        fixture = null;
-+    }
 +
 +    Path fg2output   = Paths.get("testData", "retrogradle", "fg2/decompiled.zip");
 +    Path fg2filtered = Paths.get("testData", "retrogradle", "fg2/decompiled-filtered.zip");

--- a/fernflower.gradle
+++ b/fernflower.gradle
@@ -17,6 +17,7 @@ sourceSets {
 repositories {
     mavenCentral()
     maven { url = "https://libraries.minecraft.net/" }
+    maven { url = 'https://maven.minecraftforge.net/' }
 }
 
 dependencies {
@@ -27,6 +28,7 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-core:1.3'
     testImplementation 'org.assertj:assertj-core:3.+'
     testImplementation 'com.google.code.gson:gson:2.8.0'
+    testImplementation 'net.minecraftforge:DiffPatch:2.0.5:all'
 }
 
 java.toolchain {


### PR DESCRIPTION
Diffs are output to `testData/retrogradle/output`

Required Setup:

#### testData/retrogradle/fg2/decompiled.zip
- clone 1.11.x (FG2) from <a href="https://github.com/RetroGradle/MinecraftForge">RetroGradle/MinecraftForge</a>
- `gradlew setup` (May need to be from the terminal due to gradle version)
- copy `build/localCache/decompiled.zip`

#### testData/retrogradle/fg3/output.jar
- checkout retrogradle1.11 branch
- `gradlew setup` (May require a second `gradlew setup` as the first downloads the custom MCPConfig zip)
- copy `projects/mcp/build/mcp/decompile/output.jar`