### PR TITLE
Fix patch to work on Java 8

### DIFF
--- a/FernFlower-Patches/0063-Add-Java-9-classes-to-fix-classpath-oddities.patch
+++ b/FernFlower-Patches/0063-Add-Java-9-classes-to-fix-classpath-oddities.patch
@@ -155,7 +155,7 @@ index d75c93deecbdd8c43a5f9d1a2a7a7f4e7e13e8cf..789060ca39b7ff5f897c3150554f97d0
        this.type = type;
        this.externalPath = externalPath;
        this.internalPath = internalPath;
-+      this.data = new byte[] {};
++      this.data = null;
      }
    }
  }


### PR DESCRIPTION
```
java.io.IOException: Skip failed
    at org.jetbrains.java.decompiler.util.DataInputFullStream.discard(DataInputFullStream.java:52)
    at org.jetbrains.java.decompiler.struct.lazy.LazyLoader.loadBytecode(LazyLoader.java:75)
    at org.jetbrains.java.decompiler.struct.StructMethod.expandData(StructMethod.java:121)
    at org.jetbrains.java.decompiler.main.rels.MethodProcessorRunnable.codeToJava(MethodProcessorRunnable.java:101)
    at org.jetbrains.java.decompiler.main.rels.ClassWrapper.init(ClassWrapper.java:99)
    at org.jetbrains.java.decompiler.main.ClassesProcessor.initWrappers(ClassesProcessor.java:361)
    at org.jetbrains.java.decompiler.main.ClassesProcessor.writeClass(ClassesProcessor.java:307)
    at org.jetbrains.java.decompiler.main.Fernflower.getClassContent(Fernflower.java:100)
    at org.jetbrains.java.decompiler.struct.ContextUnit.save(ContextUnit.java:177)
    at org.jetbrains.java.decompiler.struct.StructContext.saveContext(StructContext.java:77)
    at org.jetbrains.java.decompiler.main.Fernflower.decompileContext(Fernflower.java:67)
    at org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler.decompileContext(ConsoleDecompiler.java:171)
    at org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler.main(ConsoleDecompiler.java:132)
```